### PR TITLE
Fix issues when parsing paths from function names and scripts

### DIFF
--- a/src/core/script.ts
+++ b/src/core/script.ts
@@ -10,7 +10,7 @@ export class Script {
 
     constructor(
         readonly scriptId: number,
-        readonly url: Uri,
+        readonly url: Uri | undefined,
         readonly text: string
     ) {
         assert(scriptId >= 0);

--- a/src/core/sources.ts
+++ b/src/core/sources.ts
@@ -110,9 +110,9 @@ export class Sources {
     }
 
     addScript(script: Script) {
-        this.delete(script.url);
+        if (script.url) this.delete(script.url);
         this._scriptIdToScript.set(script.scriptId, script);
-        this._scriptUrlToScript.set(script.url, script);
+        if (script.url) this._scriptUrlToScript.set(script.url, script);
     }
 
     // #endregion

--- a/src/extension/model/functionName.ts
+++ b/src/extension/model/functionName.ts
@@ -9,11 +9,11 @@ import { getCanonicalUri } from "../services/canonicalPaths";
 import { compareNullable, equateNullable, hashNullable } from "../../core/utils";
 import { LocationComparer, LocationEqualer, LocationSerializer } from "../vscode/location";
 import { tryParseTrailingRange } from "../vscode/range";
-import { pathOrUriStringToUri } from "../vscode/uri";
+import { isPathOrUriString, pathOrUriStringToUri } from "../vscode/uri";
 import { KnownSerializedType, RegisteredSerializer, registerKnownSerializer } from "../../core/serializer";
 import { CodeEntry } from "../../third-party-derived/v8/tools/codeentry";
 import { FunctionState, parseFunctionState } from "../../third-party-derived/v8/enums/functionState";
-import { uriBasename } from "../../core/uri";
+import { resolveUri, uriBasename } from "../../core/uri";
 
 const functionFileRegExp = /^(?:(?<type>\w+): (?<state>[~*])?)?(?<nameAndLocation>.*)$/;
 const uriOrPathStartRegExp = /(?:[\\/](?:[a-z](?:[:|]|%3a|%7c)[\\/]?)|[a-z](?:[:|]|%3a|%7c)[\\/]?)|[a-z][-+.a-z0-9]*:/iy;
@@ -104,7 +104,9 @@ export class FunctionName {
             let location: Location | undefined;
             if (range || pathname) {
                 range ??= new Range(new Position(0, 0), new Position(0, 0));
-                const uri = pathname ? pathOrUriStringToUri(pathname) : Uri.parse("missing:", /*strict*/ true);
+                const uri = !pathname ? Uri.parse("missing:", /*strict*/ true) :
+                    isPathOrUriString(pathname) ? pathOrUriStringToUri(pathname) :
+                    resolveUri(Uri.parse("unknown:", /*strict*/ true), pathname);
                 location = new Location(getCanonicalUri(uri), range);
             }
 

--- a/src/extension/vscode/uri.ts
+++ b/src/extension/vscode/uri.ts
@@ -55,6 +55,10 @@ export function pathToFileUri(file: string, canonicalize?: boolean) {
 
 const fsAbsolutePathStartRegExp = /^(?:[\\/]|[a-z]:)/i;
 
+export function isPathOrUriString(text: string) {
+    return isUriString(text) || fsAbsolutePathStartRegExp.test(text);
+}
+
 /**
  * Converts a canonical file-system path or a canonical URI string into a canonical URI.
  */

--- a/src/third-party-derived/v8/tools/codeentry.ts
+++ b/src/third-party-derived/v8/tools/codeentry.ts
@@ -162,7 +162,10 @@ export class CodeEntry extends EntryBase {
     }
 
     protected finishInitialize() {
-        this._functionName = this.type === "RegExp" ? new FunctionName(this.getRawName(), undefined) : FunctionName.parse(this.getRawName());
+        this._functionName =
+            this.type === "SHARED_LIB" ? undefined :
+            this.type === "RegExp" ? new FunctionName(this.getRawName(), undefined) :
+            FunctionName.parse(this.getRawName());
     }
 
     static root_entry() {

--- a/src/third-party-derived/v8/tools/profile.ts
+++ b/src/third-party-derived/v8/tools/profile.ts
@@ -254,7 +254,7 @@ export class Profile {
     /**
      * Adds script source code.
      */
-    addScriptSource(scriptId: number, url: Uri, source: string) {
+    addScriptSource(scriptId: number, url: Uri | undefined, source: string) {
         this.throwIfFinalized_();
         this.sources_.addScript(new Script(scriptId, url, source));
     }
@@ -290,7 +290,7 @@ export class Profile {
         entry.start_pos ??= startPos;
         entry.end_pos ??= endPos;
         entry.script ??= script;
-        entry.filePosition ??= script && new Location(script.url, script.lineMap.positionAt(startPos));
+        entry.filePosition ??= script?.url && new Location(script.url, script.lineMap.positionAt(startPos));
 
         if (!entry?.isJSFunction?.()) return;
 
@@ -344,7 +344,7 @@ export class Profile {
                     let inline_entry = cached_inline_entries.get(cache_key);
                     if (!inline_entry) {
                         inline_entry = new DynamicFuncCodeEntry(this.sources_, 0, entry.type, pos_info.shared, FunctionState.Inlined);
-                        inline_entry.fallbackFilePosition = start_pos_info.position && new Location(pos_info.script.url, start_pos_info.position);
+                        inline_entry.fallbackFilePosition = start_pos_info.position && pos_info.script.url && new Location(pos_info.script.url, start_pos_info.position);
                         inline_entry.start_pos = pos_info.shared.start_pos;
                         inline_entry.end_pos = pos_info.shared.end_pos;
                         inline_entry.script = pos_info.script;


### PR DESCRIPTION
Function name parsing is currently very squishy because V8's output can be ambiguous. This fixes a few cases to improve parsing and to allow relative paths in some cases.

This also fixes an error in map details parsing I found while investigating this issue.

Fixes #14