### PR TITLE
Fix crash when invoking realpath on non-existent file

### DIFF
--- a/src/core/__tests__/uri.tests.ts
+++ b/src/core/__tests__/uri.tests.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Uri } from "vscode";
+import { resolveUri } from "../uri";
+
+describe("uri", () => {
+    it.each`
+
+        input                            | expected
+        ${['file://']}                   | ${'file:///'}
+        ${['file:///']}                  | ${'file:///'}
+        ${['file:///a/b']}               | ${'file:///a/b'}
+        ${['file:///a/b/']}              | ${'file:///a/b/'}
+        ${['file:///a/b/.']}             | ${'file:///a/b/'}
+        ${['file:///a/b/./c']}           | ${'file:///a/b/c'}
+        ${['file:///a/b/..']}            | ${'file:///a/'}
+        ${['file:///a/b/../c']}          | ${'file:///a/c'}
+        ${['file:///a/b', 'c']}          | ${'file:///a/c'}
+        ${['file:///a/b/', 'c']}         | ${'file:///a/b/c'}
+        ${['file:///a/b/', './c']}       | ${'file:///a/b/c'}
+        ${['file:///a/b/', '../c']}      | ${'file:///a/c'}
+        ${['file:///a/b/', '../../c']}   | ${'file:///c'}
+        ${['file:///a/b/', '.././c']}    | ${'file:///a/c'}
+        ${['file:///a/b/', '/c']}        | ${'file:///c'}
+        ${['file:///a/b/', 'http://c']}  | ${'http://c/'}
+        ${['http://a/b', '//c/d']}       | ${'http://c/d'}    // authority change replaces authority+path
+        ${['foo://a/b', 'bar:']}         | ${'bar:'}          // scheme change replaces scheme+authority+path
+        ${['foo:/a/b/.']}                | ${'foo:/a/b/'}
+        ${['foo:a/b/.']}                 | ${'foo:a/b/.'}
+
+    `("resolveUri($input)", ({ input: [base, ...parts], expected }) => {
+        const baseUri = Uri.parse(base, /*strict*/ true);
+        const actual = resolveUri(baseUri, ...parts);
+        expect(actual.toString(/*skipEncoding*/ true)).toBe(expected);
+    });
+});

--- a/src/core/uri.ts
+++ b/src/core/uri.ts
@@ -18,12 +18,12 @@ export function ensureUriTrailingDirectorySeparator(uri: Uri): Uri {
 }
 
 const isWindows = process.platform === "win32";
-const uriPathStartRegExp = /^(?:[\\/](?:[a-z](?:[:|]|%3a|%7c)[\\/]?)|[a-z](?:[:|]|%3a|%7c)[\\/]?)/i;
+const uriPathStartRegExp = /^(?:[\\/](?:[a-z](?:[:|]|%3a|%7c)[\\/]?)?|[a-z](?:[:|]|%3a|%7c)[\\/]?)/i;
 const uriSlashesRegExp = /[\\/]/g;
 const uriPartDosRootRegExp = /^[a-z](?:[:|]|%3a|%7c)$/i;
 const uriPartSingleDotRegExp = /^(?:\.|%2e)$/i;
 const uriPartDoubleDotRegExp = /^(?:\.|%2e){2}$/i;
-const uriNonNormalizedSegmentRegExp = /(?:^|[\\/])(?:\.|%2e){2}(?:$|[\\/])|\\/i;
+const uriNonNormalizedSegmentRegExp = /(?:^|[\\/])(?:\.|%2e){1,2}(?:$|[\\/])|\\/i;
 const uriNormalizedRootRegExp = /^\/(?![a-z](?:[:|]|%3[aA]|%7[cC])|[A-Z](?:[|]|%3[aA]|%7[cC]))(?:[A-Z]:\/)?/;
 
 type PathParts = [root: string, ...rest: string[]];
@@ -131,7 +131,7 @@ function isReducedPath(path: string) {
     return !uriNonNormalizedSegmentRegExp.test(path);
 }
 
-function reducePath(path: string): string {
+export function reducePath(path: string): string {
     return isReducedPath(path) ? path : joinPathParts(reducePathParts(splitPath(path)));
 }
 

--- a/src/extension/services/__tests__/canonicalPaths.tests.ts
+++ b/src/extension/services/__tests__/canonicalPaths.tests.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as fs from "fs";
+import { Uri } from "vscode";
+import { getCanonicalUri } from "../canonicalPaths";
+jest.mock("fs");
+
+describe("canonicalPaths", () => {
+    describe("getCanonicalUri", () => {
+        it.each`
+            uri                         | expected
+            ${`https://foo/bar`}        | ${`https://foo/bar`}
+            ${`https://foo/bar/../baz`} | ${`https://foo/baz`}
+            ${`foo:bar`}                | ${`foo:bar`}
+            ${`foo:/bar/../baz`}        | ${`foo:/baz`}
+        `("for non-file URI: $uri", ({ uri: uriString, expected }) => {
+            const uri = Uri.parse(uriString, /*strict*/ true);
+            const canonicalUri = getCanonicalUri(uri);
+            expect(canonicalUri.toString(/*skipEncoding*/ true)).toBe(expected);
+        });
+
+        it("for file URI when exists", () => {
+            jest.resetAllMocks();
+            const realpathNative = fs.realpathSync.native as jest.MockedFn<typeof fs.realpathSync.native>;
+            realpathNative.mockImplementationOnce(file => {
+                if (file.toString().replaceAll("\\", "/") === "/a/b/../C") return "/a/c";
+                throw new Error();
+            });
+
+            const canonicalUri = getCanonicalUri(Uri.file("/a/b/../C"));
+            expect(realpathNative).toHaveBeenCalledTimes(1);
+            expect(canonicalUri.toString(/*skipEncoding*/ true)).toBe("file:///a/c");
+        });
+
+        it("for file URI when not exists", () => {
+            jest.resetAllMocks();
+            const realpathNative = fs.realpathSync.native as jest.MockedFn<typeof fs.realpathSync.native>;
+            realpathNative.mockImplementationOnce(() => { throw new Error(); });
+
+            const canonicalUri = getCanonicalUri(Uri.file("/a/b/../C"));
+            expect(realpathNative).toHaveBeenCalledTimes(1);
+            expect(canonicalUri.toString(/*skipEncoding*/ true)).toBe("file:///a/C");
+        });
+    });
+});

--- a/src/extension/vscode/uri.ts
+++ b/src/extension/vscode/uri.ts
@@ -9,7 +9,7 @@ import { isUriString, relativeUriFragment, resolveUri } from "../../core/uri";
 import * as constants from "../constants";
 import { getScriptSourceUri } from "../fileSystemProviders/scriptSourceFileSystemProvider";
 import { LogFile } from "../model/logFile";
-import { CanonicalPath, CanonicalUri, CanonicalUriString, getCanonicalPath, getCanonicalUri } from "../services/canonicalPaths";
+import { CanonicalPath, CanonicalUri, CanonicalUriString, getCanonicalUri } from "../services/canonicalPaths";
 
 export const UNKNOWN_URI = Uri.parse(`${constants.schemes.unknown}:`);
 
@@ -53,7 +53,8 @@ export function pathToFileUri(file: string, canonicalize: true): CanonicalUri;
  */
 export function pathToFileUri(file: string, canonicalize?: boolean): Uri;
 export function pathToFileUri(file: string, canonicalize?: boolean) {
-    return Uri.file(normalizePathPosix(canonicalize ? getCanonicalPath(file) : file));
+    const uri = Uri.file(normalizePathPosix(file));
+    return canonicalize ? getCanonicalUri(uri) : uri;
 }
 
 const fsAbsolutePathStartRegExp = /^(?:[\\/]|[a-z]:)/i;
@@ -86,7 +87,7 @@ export function uriToPathOrUriString(uri: CanonicalUri): CanonicalPath | Canonic
 export function uriToPathOrUriString(uri: Uri, canonicalize: true): CanonicalPath | CanonicalUriString;
 export function uriToPathOrUriString(uri: Uri, canonicalize?: boolean): string;
 export function uriToPathOrUriString(uri: Uri, canonicalize?: boolean) {
-    if (uri.scheme === "file") return canonicalize ? getCanonicalPath(uri.fsPath) : normalizePathPosix(uri.fsPath);
+    if (uri.scheme === "file") return normalizePathPosix((canonicalize ? getCanonicalUri(uri) : uri).fsPath);
     return (canonicalize ? resolveUri(uri) : uri).toString();
 }
 

--- a/src/test/start.ts
+++ b/src/test/start.ts
@@ -18,7 +18,9 @@ export async function run(testsRoot: string, reportTestResults: (error?: Error, 
 
     for (const testResult of cliResult.results.testResults) {
         for (const assertResult of testResult.testResults) {
-            console.log(` • ${assertResult.ancestorTitles} - ${assertResult.title} [${assertResult.status}]`);
+            if (assertResult.status === "failed") {
+                console.error(` • ${assertResult.ancestorTitles} - ${assertResult.title} [${assertResult.status}]`);
+            }
         }
     }
 


### PR DESCRIPTION
This adds tests for URI normalization and canonicalization, and fixes a crash when attempting to canonicalize a non-existent path (i.e., from a foreign V8 log, or from a source map).