### PR TITLE
Fix 'splitUriPath' handling of DOS disk paths

### DIFF
--- a/src/core/__tests__/uri.tests.ts
+++ b/src/core/__tests__/uri.tests.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { Uri } from "vscode";
-import { resolveUri } from "../uri";
+import { resolveUri, splitUriPath } from "../uri";
 
 describe("uri", () => {
     it.each`
@@ -28,10 +28,44 @@ describe("uri", () => {
         ${['foo://a/b', 'bar:']}         | ${'bar:'}          // scheme change replaces scheme+authority+path
         ${['foo:/a/b/.']}                | ${'foo:/a/b/'}
         ${['foo:a/b/.']}                 | ${'foo:a/b/.'}
+        ${['file:///c%3a/foo/bar']}      | ${'file:///c:/foo/bar'}
 
     `("resolveUri($input)", ({ input: [base, ...parts], expected }) => {
         const baseUri = Uri.parse(base, /*strict*/ true);
         const actual = resolveUri(baseUri, ...parts);
         expect(actual.toString(/*skipEncoding*/ true)).toBe(expected);
+    });
+
+    it.each`
+
+        input         | expected
+        ${""}         | ${[""]}
+        ${"/"}        | ${["/"]}
+        ${"/a"}       | ${["/", "a"]}
+        ${"/a/b"}     | ${["/", "a", "b"]}
+        ${"/c:"}      | ${["/C:/"]}
+        ${"/c:/"}     | ${["/C:/"]}
+        ${"/c:/a"}    | ${["/C:/", "a"]}
+        ${"/c|"}      | ${["/C:/"]}
+        ${"/c|/"}     | ${["/C:/"]}
+        ${"/c|/a"}    | ${["/C:/", "a"]}
+        ${"/c%3a"}    | ${["/C:/"]}
+        ${"/c%3a/"}   | ${["/C:/"]}
+        ${"/c%3a/a"}  | ${["/C:/", "a"]}
+        ${"/c%3A"}    | ${["/C:/"]}
+        ${"/c%3A/"}   | ${["/C:/"]}
+        ${"/c%3A/a"}  | ${["/C:/", "a"]}
+        ${"/c%7c"}    | ${["/C:/"]}
+        ${"/c%7c/"}   | ${["/C:/"]}
+        ${"/c%7c/a"}  | ${["/C:/", "a"]}
+        ${"/c%7C"}    | ${["/C:/"]}
+        ${"/c%7C/"}   | ${["/C:/"]}
+        ${"/c%7C/a"}  | ${["/C:/", "a"]}
+        ${"c:"}       | ${["/C:/"]}
+        ${"c:/"}      | ${["/C:/"]}
+        ${"c:/a"}     | ${["/C:/", "a"]}
+
+    `("splitUriPath($input)", ({ input, expected }) => {
+        expect(splitUriPath(input)).toEqual(expected);
     });
 });

--- a/src/extension/services/canonicalPaths.ts
+++ b/src/extension/services/canonicalPaths.ts
@@ -2,10 +2,9 @@
 // Licensed under the MIT License.
 
 import * as fs from "fs";
-import { fileURLToPath, URL } from "url";
-import { Disposable, ExtensionContext, Location, Uri } from "vscode";
+import { ExtensionContext, Location, Uri } from "vscode";
 import { isFileSystemLocation, normalizePathPosix } from "../../core/paths";
-import { isUriString, reducePath, resolveUri } from "../../core/uri";
+import { reducePath, resolveUri } from "../../core/uri";
 import { VSDisposableStack } from "../vscode/disposable";
 
 declare const canonicalPath: unique symbol;


### PR DESCRIPTION
Fixes an issue with path normalization affecting the ability to open a log file on Windows.