### PR TITLE
Map 'file' Uris to 'vscode-remote' Uris as needed

### DIFF
--- a/src/core/fs.ts
+++ b/src/core/fs.ts
@@ -6,6 +6,7 @@ import { URL } from "url";
 import { TextDecoder } from "util";
 import { FileStat, FileType, Uri, workspace } from "vscode";
 import { assert } from "./assert";
+import { isUriString } from "./uri";
 
 // /**
 //  * Attempts a synchronous stat(2) to get file status.
@@ -124,7 +125,10 @@ async function* vscodeReadLines(file: Uri) {
 export function readFileAsync(file: string): Promise<string>;
 export function readFileAsync(uri: Uri): Promise<string>;
 export async function readFileAsync(uri: Uri | string) {
-    const data = await workspace.fs.readFile(typeof uri === "string" ? Uri.file(uri) : uri);
+    if (typeof uri === "string") {
+        uri = isUriString(uri) ? Uri.parse(uri, /*strict*/ true) : Uri.file(uri);
+    }
+    const data = await workspace.fs.readFile(uri);
     return Buffer.from(data).toString("utf8");
 }
 
@@ -141,5 +145,8 @@ export async function tryReadFileAsync(uri: Uri | string) {
 export function writeFileAsync(file: string, content: string): Promise<void>;
 export function writeFileAsync(uri: Uri, content: string): Promise<void>;
 export async function writeFileAsync(uri: Uri | string, content: string) {
-    await workspace.fs.writeFile(typeof uri === "string" ? Uri.file(uri) : uri, Buffer.from(content, "utf8"));
+    if (typeof uri === "string") {
+        uri = isUriString(uri) ? Uri.parse(uri, /*strict*/ true) : Uri.file(uri);
+    }
+    await workspace.fs.writeFile(uri, Buffer.from(content, "utf8"));
 }

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -7,10 +7,10 @@ import { Uri } from "vscode";
 import { isUriString } from "./uri";
 
 export function isFileSystemLocation(file: string | Uri | URL) {
-    if (file instanceof Uri) return file.scheme === "file";
-    if (file instanceof URL) return file.protocol === "file:";
+    if (file instanceof Uri) return file.scheme === "file" || file.scheme === "vscode-remote";
+    if (file instanceof URL) return file.protocol === "file:" || file.protocol === "vscode-remote:";
     if (typeof file !== "string") return false;
-    if (isUriString(file)) return file.startsWith("file://");
+    if (isUriString(file)) return file.startsWith("file://") || file.startsWith("vscode-remote://");
     return path.isAbsolute(file);
 }
 


### PR DESCRIPTION
This maps `file:` uris to `vscode-remote:` uris as needed to properly open files when running under VS Code Remote (i.e., WSL, SSH, or a dev container).

This also makes changes to the precedence we use to determine whether to read from disk or from sources recorded in the log to favor the file on disk so that edits can be made.

Fixes #26