### PR TITLE
[dexnode] Always use a temp file for `--redirect-code-traces-to`

### DIFF
--- a/tools/dexnode/package.json
+++ b/tools/dexnode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexnode",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Run NodeJS with logging options needed by Deopt Explorer",
   "type": "module",
   "bin": {

--- a/tools/dexnode/src/util.ts
+++ b/tools/dexnode/src/util.ts
@@ -24,22 +24,6 @@ export function canAccess(file: string, mode: "write" | "exec") {
     }
 }
 
-export function canAppend(file: string) {
-    try {
-        const fd = fs.openSync(file, "a");
-        try {
-            const stat = fs.fstatSync(fd);
-            return !!(stat.mode & fs.constants.S_IFREG);
-        }
-        finally {
-            fs.closeSync(fd);
-        }
-    }
-    catch {
-        return false;
-    }
-}
-
 export async function regQuery(hive: string, key: string, valueName: string = Registry.DEFAULT_VALUE) {
     const reg = new Registry({ hive, key });
     const keyExists = await new Promise<boolean>((res, rej) => reg.keyExists((err, exists) => err ? rej(err) : res(exists)));


### PR DESCRIPTION
Rather than trying to work around os-specific issues related to `/dev/null`, this just changes `dexnode` to always generate a temp file for later cleanup.

Fixes #45 
