### PR TITLE
Add repository info to the dexnode `package.json`

### DIFF
--- a/tools/dexnode/package.json
+++ b/tools/dexnode/package.json
@@ -14,6 +14,11 @@
   ],
   "author": "Ron Buckton <ron.buckton@microsoft.com>",
   "license": "MIT",
+    "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/deoptexplorer-vscode.git",
+    "directory": "tools/dexnode"
+  },
   "dependencies": {
     "semver": "^7.3.8",
     "winreg": "^1.2.4"


### PR DESCRIPTION
When navigating on npmjs, I was wondering if dexcode was open source. It wasn't straightforward to find the source code, so this will improve that. 

This will reference the repo on npmjs and reference to the source code directly.